### PR TITLE
Support options in customPreprocessors

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,7 +8,7 @@ function createPreprocessor(args, config, logger, helper) {
 
   function preprocess(content, file, done) {
     log.debug('Processing "%s".', file.originalPath);
-    var options = createOptions(config, file);
+    var options = createOptions(args, config, helper, file);
     file.path = options.filename || file.path;
 
     try {
@@ -23,9 +23,9 @@ function createPreprocessor(args, config, logger, helper) {
   return preprocess;
 }
 
-function createOptions(config, file) {
+function createOptions(args, config, helper, file) {
   config = config || {};
-  var options = extend({ filename: file.originalPath }, config.options || {});
+  var options = helper.merge({ filename: file.originalPath }, args.options || {}, config.options || {});
   Object.keys(config).forEach(function(optionName) {
     if (optionName === 'options') {
       return;


### PR DESCRIPTION
This pull request allows users to specify the [`customPreprocessors`](http://karma-runner.github.io/0.12/config/preprocessors.html) option in their `karma.conf.js`. For example:
```js
customPreprocessors: {
  babel_with_modules: {
    base: "babel",
    options: {
      modules: "system"
    }
  },
  babel_no_modules: {
    base: "babel",
    options: {
      modules: "ignore"
    }
  }
}
```

*Edits adapted from [karma-coffee-preprocessor](https://github.com/karma-runner/karma-coffee-preprocessor/blob/master/index.js#L11)*