### PR TITLE
Support Babel 7

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,10 +27,11 @@
     "email": "shuhei.kagawa@gmail.com"
   },
   "license": "ISC",
-  "dependencies": {
+  "peerDependencies": {
     "babel-core": "^6.0.0"
   },
   "devDependencies": {
+    "babel-core": "^6.0.0",
     "babel-polyfill": "^6.0.2",
     "babel-preset-es2015": "^6.0.12",
     "jasmine-core": "^2.3.4",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   },
   "license": "ISC",
   "peerDependencies": {
-    "babel-core": "^6.0.0"
+    "babel-core": "6 || 7 || ^7.0.0-alpha || ^7.0.0-beta || ^7.0.0-rc"
   },
   "devDependencies": {
     "babel-core": "^6.0.0",


### PR DESCRIPTION
* Make `babel-core` a peer dependency, similar to [babel-loader](https://github.com/babel/babel-loader/blob/1ca5c7856d2129a28d6ba031bd8a5759aa80b8eb/package.json#L18) and [gulp-babel](https://github.com/babel/gulp-babel/blob/8e6fa78bab83f0d0eda65a281a1e4a39d119d262/package.json#L43)
* Support Babel 7, similar to babel/babel-loader#403

Note that this will require a major version bump.