### PR TITLE
Pass through original code if Babel has ignored

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -17,8 +17,12 @@ function createPreprocessor(args, config, logger, helper) {
       var options = createOptions(args, config, helper, file);
       file.path = options.filename || file.path;
 
-      var processed = babel.transform(content, options).code;
-      done(null, processed);
+      var processed = babel.transform(content, options);
+      var code = content;
+      if (processed) {
+        code = processed.code;
+      }
+      done(null, code);
     } catch (e) {
       log.error('%s\n at %s', e.message, file.originalPath);
       done(e, null);


### PR DESCRIPTION
In Babel v7 when a file has been ignored "transform" returns null (in Babel v6 the original code was returned).
In this case karma-babel-preprocessor errors as it tries to access the property "code" on the null value.

See https://babeljs.io/docs/en/v7-migration-api
"Calls to babel.transform or any other transform function may return null if the file matched an ignore pattern or failed to match an only pattern"