### PR TITLE
Switch to GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,20 @@
+name: CI
+
+on: [push, pull_request]
+
+jobs:
+  test:
+    name: Test on Node.js # GitHub will add ${{ matrix.node-version }} to this title
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node-version: [14, 12, 10, 8, 6]
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v2-beta
+        with:
+          node-version: ${{ matrix.node-version }}
+      - run: npm install
+      - run: npm test

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,0 @@
-language: node_js
-node_js:
-  - 'stable'
-  - '8'
-  - '6'


### PR DESCRIPTION
@nicolo-ribaudo informed me that Travis CI is no longer running on any repositories in the @babel organization, so this PR switches us over to GitHub Actions. 🙂